### PR TITLE
Rename to smart_proxy_openscap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-foreman-proxy_openscap-*.gem
+smart_proxy_openscap-*.gem
 .idea

--- a/README.md
+++ b/README.md
@@ -15,35 +15,35 @@ Learn more about [Foreman-OpenSCAP](https://github.com/OpenSCAP/foreman_openscap
 
 - Enable [isimluk/OpenSCAP](https://copr.fedoraproject.org/coprs/isimluk/OpenSCAP/) COPR repository
 
-- Install Foreman-proxy_OpenSCAP
+- Install smart_proxy_openscap
 
   ```
-  # yum install rubygem-foreman-proxy_openscap
+  # yum install rubygem-smart_proxy_openscap
   ```
 
 ## Installation from upstream git
 
 - Install foreman-proxy from Foreman-proxy upstream
-- Download foreman-proxy_openscap
+- Download smart_proxy_openscap
 
   ```
-  ~$ git clone https://github.com/OpenSCAP/foreman-proxy_openscap.git
+  ~$ git clone https://github.com/OpenSCAP/smart_proxy_openscap.git
   ```
 
-- Build foreman-proxy_openscap RPM
+- Build smart_proxy_openscap RPM
 
   ```
-  ~$ cd foreman-proxy_openscap
-  ~$ gem build foreman_proxy_openscap.gemspec
+  ~$ cd smart_proxy_openscap
+  ~$ gem build smart_proxy_openscap.gemspec
   ~# yum install yum-utils rpm-build
-  ~# yum-builddep extra/rubygem-foreman-proxy_openscap.spec
-  ~# rpmbuild  --define "_sourcedir `pwd`" -ba extra/rubygem-foreman-proxy_openscap.spec
+  ~# yum-builddep extra/rubygem-smartproxy_openscap.spec
+  ~# rpmbuild  --define "_sourcedir `pwd`" -ba extra/rubygem-smart_proxy_openscap.spec
   ```
 
-- Install rubygem-forman-proxy_openscap
+- Install rubygem-smart_proxy_openscap
 
   ```
-  ~$ yum local install ~/rpmbuild/RPMS/noarch/rubygem-foreman-proxy_openscap*
+  ~$ yum local install ~/rpmbuild/RPMS/noarch/rubygem-smart_proxy_openscap*
   ```
 
 If you don't install through RPM but you are using bundler, you may need to create 
@@ -70,7 +70,7 @@ foreman-proxy runs.
 
 ## Copyright
 
-Copyright (c) 2014 Red Hat, Inc.
+Copyright (c) 2014--2015 Red Hat, Inc.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/bin/smart-proxy-openscap-send
+++ b/bin/smart-proxy-openscap-send
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (c) 2014 Red Hat Inc.
+# Copyright (c) 2014--2015 Red Hat Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 3 (GPLv3). There is NO WARRANTY for this software, express or
@@ -13,8 +13,8 @@ $LOAD_PATH.unshift '/usr/share/foreman-proxy/lib'
 $LOAD_PATH.unshift '/usr/share/foreman-proxy/modules'
 
 require 'smart_proxy'
-require 'foreman-proxy_openscap'
-require 'foreman-proxy_openscap/openscap_lib'
+require 'smart_proxy_openscap'
+require 'smart_proxy_openscap/openscap_lib'
 
 # Don't run if OpenSCAP plugin is disabled.
 exit unless Proxy::OpenSCAP::Plugin.settings.enabled == true

--- a/bundler.d/openscap.rb
+++ b/bundler.d/openscap.rb
@@ -1,5 +1,5 @@
 # Drop this file into bundler.d/ in foreman-proxy root
-gem 'foreman-proxy_openscap'
+gem 'smart_proxy_openscap'
 
 group :openscap do
   # plugin dependencies go here

--- a/extra/foreman-proxy-openscap-send.cron
+++ b/extra/foreman-proxy-openscap-send.cron
@@ -1,2 +1,0 @@
-# Send all collected OpenSCAP reports once every 30 minutes
-*/30 * * * * foreman-proxy foreman-proxy-openscap-send >>/var/log/foreman-proxy/cron.log 2>&1

--- a/extra/rubygem-smart_proxy_openscap.spec
+++ b/extra/rubygem-smart_proxy_openscap.spec
@@ -1,4 +1,4 @@
-%global gem_name foreman-proxy_openscap
+%global gem_name smart_proxy_openscap
 
 %global foreman_proxy_bundlerd_dir /usr/share/foreman-proxy/bundler.d
 %global foreman_proxy_pluginconf_dir /etc/foreman-proxy/settings.d
@@ -7,11 +7,11 @@
 
 Name: rubygem-%{gem_name}
 Version: 0.1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: OpenSCAP plug-in for Foreman's smart-proxy.
 Group: Applications/Internet
 License: GPLv2+
-URL: http://github.com/openscap/foreman-proxy_openscap
+URL: http://github.com/openscap/smart_proxy_openscap
 Source0: https://rubygems.org/gems/%{gem_name}-%{version}.gem
 #Requires: ruby(release)
 Requires: ruby(rubygems)
@@ -22,6 +22,7 @@ BuildRequires: rubygems-devel
 BuildRequires: ruby
 BuildArch: noarch
 Provides: rubygem(%{gem_name}) = %{version}
+Obsoletes: rubygem-foreman-proxy_openscap
 
 %description
 A plug-in to the Foreman's smart-proxy which receives bzip2ed ARF files
@@ -44,7 +45,7 @@ gem build %{gem_name}.gemspec
 mkdir -p %{buildroot}%{gem_dir}
 cp -a .%{gem_dir}/* \
        %{buildroot}%{gem_dir}/
-mv %{buildroot}%{gem_instdir}/foreman-proxy_openscap.gemspec %{buildroot}/%{gem_spec}
+mv %{buildroot}%{gem_instdir}/%{gem_name}.gemspec %{buildroot}/%{gem_spec}
 rm %{buildroot}%{gem_instdir}/extra/*.spec # this specfile
 
 # executables
@@ -64,7 +65,7 @@ mv %{buildroot}%{gem_instdir}/settings.d/openscap.yml.example \
 
 # crontab
 mkdir -p %{buildroot}%{_sysconfdir}/cron.d/
-mv %{buildroot}%{gem_instdir}/extra/foreman-proxy-openscap-send.cron \
+mv %{buildroot}%{gem_instdir}/extra/smart-proxy-openscap-send.cron \
    %{buildroot}%{_sysconfdir}/cron.d/%{name}
 
 # create spool directory
@@ -78,7 +79,7 @@ mkdir -p %{buildroot}%{spool_dir}
 
 %attr(-,%{proxy_user},%{proxy_user}) %{spool_dir}
 %{foreman_proxy_bundlerd_dir}/openscap.rb
-%{_bindir}/foreman-proxy-openscap-send
+%{_bindir}/smart-proxy-openscap-send
 %doc %{foreman_proxy_pluginconf_dir}/openscap.yml.example
 %config(noreplace) %attr(0644, root, root) %{_sysconfdir}/cron.d/%{name}
 
@@ -87,6 +88,9 @@ mkdir -p %{buildroot}%{spool_dir}
 %{gem_instdir}/COPYING
 
 %changelog
+* Tue Jan 20 2015 Šimon Lukašík <slukasik@redhat.com> - 0.1.0-2
+- renamed to smart_proxy_openscap
+
 * Fri Oct 24 2014 Šimon Lukašík <slukasik@redhat.com> - 0.1.0-1
 - rebuilt
 

--- a/extra/smart-proxy-openscap-send.cron
+++ b/extra/smart-proxy-openscap-send.cron
@@ -1,0 +1,2 @@
+# Send all collected OpenSCAP reports once every 30 minutes
+*/30 * * * * foreman-proxy smart-proxy-openscap-send >>/var/log/foreman-proxy/cron.log 2>&1

--- a/lib/smart_proxy_openscap.rb
+++ b/lib/smart_proxy_openscap.rb
@@ -8,9 +8,7 @@
 # along with this software; if not, see http://www.gnu.org/licenses/gpl.txt
 #
 
-module Proxy
-  module OpenSCAP
-    VERSION = '0.1.0'
-  end
-end
+require 'smart_proxy_openscap/openscap_plugin'
 
+module Proxy::OpenSCAP
+end

--- a/lib/smart_proxy_openscap/http_config.ru
+++ b/lib/smart_proxy_openscap/http_config.ru
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 Red Hat Inc.
+# Copyright (c) 2014--2015 Red Hat Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 3 (GPLv3). There is NO WARRANTY for this software, express or
@@ -8,9 +8,8 @@
 # along with this software; if not, see http://www.gnu.org/licenses/gpl.txt
 #
 
-require 'foreman-proxy_openscap/openscap_api'
+require 'smart_proxy_openscap/openscap_api'
 
 map '/compliance' do
   run Proxy::OpenSCAP::Api
 end
-

--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 Red Hat Inc.
+# Copyright (c) 2014--2015 Red Hat Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 3 (GPLv3). There is NO WARRANTY for this software, express or
@@ -8,7 +8,7 @@
 # along with this software; if not, see http://www.gnu.org/licenses/gpl.txt
 #
 
-require 'foreman-proxy_openscap/openscap_lib'
+require 'smart_proxy_openscap/openscap_lib'
 
 module Proxy::OpenSCAP
   class Api < ::Sinatra::Base
@@ -44,4 +44,3 @@ module Proxy::OpenSCAP
     end
   end
 end
-

--- a/lib/smart_proxy_openscap/openscap_lib.rb
+++ b/lib/smart_proxy_openscap/openscap_lib.rb
@@ -153,4 +153,3 @@ module Proxy::OpenSCAP
     end
   end
 end
-

--- a/lib/smart_proxy_openscap/openscap_plugin.rb
+++ b/lib/smart_proxy_openscap/openscap_plugin.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014 Red Hat Inc.
+# Copyright (c) 2014--2015 Red Hat Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 3 (GPLv3). There is NO WARRANTY for this software, express or
@@ -8,7 +8,7 @@
 # along with this software; if not, see http://www.gnu.org/licenses/gpl.txt
 #
 
-require 'foreman-proxy_openscap/openscap_version'
+require 'smart_proxy_openscap/openscap_version'
 
 module Proxy::OpenSCAP
   class Plugin < ::Proxy::Plugin
@@ -21,4 +21,3 @@ module Proxy::OpenSCAP
                      :openscap_send_log_file => '/var/log/foreman-proxy/openscap-send.log'
   end
 end
-

--- a/lib/smart_proxy_openscap/openscap_version.rb
+++ b/lib/smart_proxy_openscap/openscap_version.rb
@@ -8,8 +8,8 @@
 # along with this software; if not, see http://www.gnu.org/licenses/gpl.txt
 #
 
-require 'foreman-proxy_openscap/openscap_plugin'
-
-module Proxy::OpenSCAP
+module Proxy
+  module OpenSCAP
+    VERSION = '0.1.0'
+  end
 end
-

--- a/smart_proxy_openscap.gemspec
+++ b/smart_proxy_openscap.gemspec
@@ -1,7 +1,7 @@
-require File.expand_path('../lib/foreman-proxy_openscap/openscap_version', __FILE__)
+require File.expand_path('../lib/smart_proxy_openscap/openscap_version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.name = 'foreman-proxy_openscap'
+  s.name = 'smart_proxy_openscap'
   s.version = Proxy::OpenSCAP::VERSION
   s.summary = "OpenSCAP plug-in for Foreman's smart-proxy."
   s.description = "A plug-in to the Foreman's smart-proxy which receives
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
 
   s.author = 'Šimon Lukašík'
   s.email = 'slukasik@redhat.com'
-  s.homepage = 'http://github.com/OpenSCAP/foreman-proxy_openscap'
+  s.homepage = 'http://github.com/OpenSCAP/smart_proxy_openscap'
   s.license = 'GPL-3'
 
   s.files = `git ls-files`.split("\n") - ['.gitignore']
-  s.executables = ['foreman-proxy-openscap-send']
+  s.executables = ['smart-proxy-openscap-send']
 end


### PR DESCRIPTION
To comply with Foreman's plug-in naming convention.

Fixes #5.